### PR TITLE
Style CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+﻿---
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: 'true'
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'true'
+AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: 'true'
+AlwaysBreakTemplateDeclarations: 'true'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakConstructorInitializersBeforeComma: 'false'
+ColumnLimit: '80'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+ConstructorInitializerIndentWidth: '0'
+Cpp11BracedListStyle: 'true'
+DerivePointerAlignment: 'true'
+DisableFormat: 'false'
+IndentCaseLabels: 'true'
+IndentWidth: 4
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '2'
+NamespaceIndentation: Inner
+ReflowComments: 'false'
+SpaceAfterCStyleCast: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: Cpp11
+UseTab: Never
+TabWidth: 4
+SortIncludes: false
+AccessModifierOffset: -2
+
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: false
+  SplitEmptyRecord: false
+BreakBeforeBraces: Allman
+BreakBeforeBinaryOperators: All

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,20 @@
+name: style
+
+on: 
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.11
+      with:
+        source: '.'
+        exclude: './DaisySP ./libDaisy'
+        extensions: 'h,cpp'
+        clangFormatVersion: 10
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # DaisyActionTest
 
 ![Build Workflow](https://github.com/stephenhensley/DaisyActionTest/workflows/Build%20All/badge.svg)
+![Build Workflow](https://github.com/stephenhensley/DaisyActionTest/workflows/Style/badge.svg)
 
 Repo to test github actions for the Daisy ecosystem

--- a/examples/blink/blink.cpp
+++ b/examples/blink/blink.cpp
@@ -1,11 +1,12 @@
 #include "daisy_seed.h"
 static daisy::DaisySeed hw;
+
 int main(void)
 {
     bool state = false;
     hw.Configure();
     hw.Init();
-    for (;;)
+    for(;;)
     {
         hw.SetLed(state);
         state = !state;

--- a/examples/passthru/passthru.cpp
+++ b/examples/passthru/passthru.cpp
@@ -3,7 +3,7 @@
 
 static daisy::DaisySeed hw;
 
-void passthru(float **in, float**out, size_t size)
+void passthru(float **in, float **out, size_t size)
 {
     memcpy(out, in, size * 2 * sizeof(in[0][0]));
 }
@@ -14,7 +14,7 @@ int main(void)
     hw.Configure();
     hw.Init();
     hw.StartAudio(passthru);
-    for (;;)
+    for(;;)
     {
         hw.SetLed(state);
         state = !state;


### PR DESCRIPTION
Added style workflow. Still need a good non-docker way to test it locally. Looks like the workflow uses the same `run-clang-format.py` script that we use for libdaisy, etc.